### PR TITLE
Update README.md

### DIFF
--- a/Proposal Alternative.md
+++ b/Proposal Alternative.md
@@ -1,0 +1,56 @@
+# tei-proposal
+Test repository for a new proposal for TEI
+
+## Requirements:
+1. Able to say what unit it's refering to
+2. Flexible way of treating citations patterns (regex probably)
+3. Hierarchical and able to deal with mixed kind of contents
+4. Easy enough to parse so that you can extract a table of contents or list of passage references from your document
+5. Able to provide a passage name as well as an identifier
+6. Able to provide different refsDecl depending on the objective
+
+## Proposal 1: Combine refState and cRefPattern
+(example constructed for https://github.com/sjhuskey/Calpurnius_Siculus/blob/master/editio.xml)
+
+```XML
+<encodingDesc>
+  <refsDecl type="canonical">
+
+    <tocItem 
+      unit="front"
+      discover="//front/div[@type='introduction']/div[@type='section']"
+      matchPattern="Introduction (\w+)"
+      xPathPattern="//front/div[@type='introduction']/div[@type='section'][@n='$1']"
+      >
+      <metadataDecl type="dc:title" xPathPattern=".//head" />
+      <metadataDecl type="dc:author" xPathPattern="./persName[@type='author']" />
+    </tocItem>
+
+    <tocItem 
+      unit="poem"
+      discover="//body/div[@type='edition']/div[@type='textpart']"
+      matchPattern="(\d)"
+      xPathPattern="//body/div[@type='edition']/div[@type='textpart'][@n='$1']"
+      >
+
+      <tocItem 
+        unit="line"
+        discover=".//l[parent::div or parent::lem]"
+        matchPattern="(\d)\.(\d+)"
+        xPathPattern="//body/div[@type='edition']/div[@type='textpart'][@n='$1]//l[parent::div or parent::lem][@n='$2']"
+        >
+      </tocItem>
+
+    </tocItem>
+
+  </refsDecl>
+</encodingDesc>
+```
+### Notes:
+* Satisfies #1 with `@unit` on refState
+* Satisfies #2 with a `@matchPattern` inside `tocPattern`
+* Satisfies #3 with nested `tocPattern`. RefStates at the same level should be considered alternates.
+* Satisfies #4 with `@discover` and `@use`. Nested `@discover`es use relative XPaths.  
+* Satisfies #5 with `metadataDecl` which provides an `@xPathPattern` and a `@type` for metadata plurality (epistolary exchange can have different authors, dates, etc.)
+* Statisfies #6 with `@type` on `refsDecl`
+* TODO: algorithm for generating passage IDs at any level using the example.

--- a/README.md
+++ b/README.md
@@ -7,32 +7,50 @@ Test repository for a new proposal for TEI
 3. Hierarchical and able to deal with mixed kind of contents
 4. Easy enough to parse so that you can extract a table of contents or list of passage references from your document
 5. Able to provide a passage name as well as an identifier
-
+6. Able to provide different refsDecl depending on the objective
 
 ## Proposal 1: Combine refState and cRefPattern
 (example constructed for https://github.com/sjhuskey/Calpurnius_Siculus/blob/master/editio.xml)
+
 ```XML
 <encodingDesc>
-  <refsDecl>
-    <refState unit="front" match="//front/div[@type='introduction']/div[@type='section']" use="head">
-      <cRefPattern matchPattern="Introduction (\w+)" 
-                   replacementPattern="#xpath(//front/div[@type='introduction']/div[@type='section'][@n='$1'])"/>
-    </refState>
-    <refState unit="poem" match="//body/div[@type='edition']/div[@type='textpart']" use="@n" altName="head" delim=".">
-      <cRefPattern matchPattern="(\d)" 
-                   replacementPattern="#xpath(//body/div[@type='edition']/div[@type='textpart'][@n='$1']"/>
-      <refState unit="line" match=".//l[parent::div or parent::lem]" use="@n">
-        <cRefPattern matchPattern="(\d)\.(\d)" 
-                     replacementPattern="#xpath(//body/div[@type='edition']/div[@type='textpart'][@n='$1]//l[parent::div or parent::lem][@n='$2'])"/>
-      </refState>
-    </refState>
+  <refsDecl type="canonical">
+
+    <tocItem 
+      unit="front"
+      discover="//front/div[@type='introduction']/div[@type='section']"
+      matchPattern="Introduction (\w+)"
+      xPathPattern="//front/div[@type='introduction']/div[@type='section'][@n='$1']"
+      >
+      <metadataDecl type="dc:title" xPathPattern=".//head" />
+      <metadataDecl type="dc:author" xPathPattern="./persName[@type='author']" />
+    </tocItem>
+
+    <tocItem 
+      unit="poem"
+      discover="//body/div[@type='edition']/div[@type='textpart']"
+      matchPattern="(\d)"
+      xPathPattern="//body/div[@type='edition']/div[@type='textpart'][@n='$1']"
+      >
+
+      <tocItem 
+        unit="line"
+        discover=".//l[parent::div or parent::lem]"
+        matchPattern="(\d)\.(\d+)"
+        xPathPattern="//body/div[@type='edition']/div[@type='textpart'][@n='$1]//l[parent::div or parent::lem][@n='$2']"
+        >
+      </tocItem>
+
+    </tocItem>
+
   </refsDecl>
 </encodingDesc>
 ```
 ### Notes:
 * Satisfies #1 with `@unit` on refState
-* Satisfies #2 with a cRefPattern child of the refState. Consider using a different attribute than `@replacementPattern` or otherwise changing its datatype to be an XPath instead of a URI.
-* Satisfies #3 with nested refStates. RefStates at the same level should be considered alternates.
-* Satisfies #4 with `@match` and `@use`. Nested `@match`es use relative XPaths. 
-* Satisfies #5 with `@altName` on refState, which provides an XPath relative to `@match` which references a node containing a name for the passage.
+* Satisfies #2 with a `@matchPattern` inside `tocPattern`
+* Satisfies #3 with nested `tocPattern`. RefStates at the same level should be considered alternates.
+* Satisfies #4 with `@discover` and `@use`. Nested `@discover`es use relative XPaths.  
+* Satisfies #5 with `metadataDecl` which provides an `@xPathPattern` and a `@type` for metadata plurality (epistolary exchange can have different authors, dates, etc.)
+* Statisfies #6 with `@type` on `refsDecl`
 * TODO: algorithm for generating passage IDs at any level using the example.


### PR DESCRIPTION
The #4 is something I am definitely not happy with, I see the need but the duplication in `@use` is problematic to me. Could the `discover` actually targets the identifier holder instead of the passage ?

I renamed elements for the moment because it seems easier to read. If we end up using something else, I'll be ok with it.